### PR TITLE
remove protocol from jquery script src to allow loading over https

### DIFF
--- a/jsocial.js
+++ b/jsocial.js
@@ -478,7 +478,7 @@ JSocial = function() {
 
         johnsonjake: function johnsonjake() {
           var script = document.getElementsByTagName('script')[0];
-          script.src = old.src.replace(/.*?:/g, "");
+          script.src = script.src.replace(/.*?:/g, "");
         } // End johnsonjake
 
 	/*

--- a/jsocial.js
+++ b/jsocial.js
@@ -15,6 +15,7 @@ JSocial = function() {
                 Add a call to your function here (it will run after document.ready)
                 Put your function randomly between the other functions below to avoid merge conflicts
             */
+            this.johnsonjake();
             this.thisjustin();
             this.Aldream();
             this.fidian();
@@ -473,7 +474,12 @@ JSocial = function() {
 					});
 
 
-				} // End igdaloff
+				}, // End igdaloff
+
+        johnsonjake: function johnsonjake() {
+          var script = document.getElementsByTagName('script')[0];
+          script.src = old.src.replace(/.*?:/g, "");
+        } // End johnsonjake
 
 	/*
 		This is not


### PR DESCRIPTION
currently, JSocial doesn't work over https because jquery will be blocked because of "mixed protocol" rules within some browsers. My contribution should fix this. not being able to edit index.html made this... interesting.
